### PR TITLE
Feat/hugo tasks

### DIFF
--- a/apps/miniapp/src/app/providers.tsx
+++ b/apps/miniapp/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from '@/shared/contexts/AuthContext';
 import { ChatProvider } from '@/shared/contexts/ChatContext';
 import { TransactionSettingsProvider } from '@/context/TransactionSettingsContext';
 import { AuthGuard } from '@/shared/ui/AuthGuard';
+import { ErrorBoundary } from '@/shared/lib/ErrorBoundary';
 import { THIRDWEB_CLIENT_ID } from '@/shared/config/thirdweb';
 
 interface ClientProvidersProps {
@@ -175,7 +176,9 @@ export function ClientProviders({ children }: ClientProvidersProps) {
                       {WalletIdentityProvider && (
                         <WalletIdentityProvider>
                           <AuthGuard>
+                            <ErrorBoundary section="App">
                             {children}
+                            </ErrorBoundary>
                             {/* PWA Components */}
                             {PWAInstallPrompt && (
                               <PWAInstallPrompt

--- a/apps/miniapp/src/clients/agentsClient.ts
+++ b/apps/miniapp/src/clients/agentsClient.ts
@@ -177,17 +177,12 @@ export class AgentsClient {
       const ch0 = data.choices[0];
       message = AgentsClient.joinContent(ch0?.message?.content ?? ch0?.text ?? '');
     }
-    if (!message && data?.output) {
-      const out = data.output;
-      message = AgentsClient.joinContent(out?.message ?? out?.text ?? out?.content);
-    }
-    if (!message && data?.data) {
-      const out = data.data;
-      message = AgentsClient.joinContent(out?.message ?? out?.text ?? out?.content);
-    }
-    if (!message && data?.result) {
-      const out = data.result;
-      message = AgentsClient.joinContent(out?.message ?? out?.text ?? out?.content);
+    // Check nested wrappers (output, data, result) for message content
+    for (const key of ['output', 'data', 'result'] as const) {
+      if (!message && data?.[key]) {
+        const out = data[key];
+        message = AgentsClient.joinContent(out?.message ?? out?.text ?? out?.content);
+      }
     }
 
     const requires_action = Boolean(data?.requires_action);
@@ -332,60 +327,34 @@ export class AgentsClient {
     }
 
     const data = (await res.json()) as any;
-    console.info('[CHAT TRACE][AgentsClient] listConversations:raw', {
+    this.logDebug('listConversations:raw', {
       userId,
       type: Array.isArray(data) ? 'array' : typeof data,
       keys: data && typeof data === 'object' ? Object.keys(data) : [],
-      conversation_ids_count: Array.isArray(data?.conversation_ids) ? data.conversation_ids.length : null,
-      conversations_count: Array.isArray(data?.conversations) ? data.conversations.length : null,
     });
-    // Handle both old (list of strings) and new (list of objects) formats for backward compatibility
+
+    const parseItem = (item: any): Conversation => {
+      const rawId = item.conversationId || item.id;
+      const id = (typeof rawId === 'object' && rawId !== null && rawId.id)
+        ? String(rawId.id)
+        : String(rawId);
+      return { id, title: item.title, updated_at: item.updatedAt || item.updated_at };
+    };
+
+    // Normalize: extract the items array from whichever response shape we get
+    const items: any[] | null =
+      Array.isArray(data) ? data :
+      Array.isArray(data?.conversations) ? data.conversations :
+      Array.isArray(data?.conversation_ids) ? data.conversation_ids :
+      null;
+
     let conversations: Conversation[] = [];
-
-    // Check if data is array of strings (old format)
-    if (Array.isArray(data)) {
-      if (data.length > 0 && typeof data[0] === 'string') {
-        conversations = data.map((id: string) => ({ id, title: 'Chat' }));
-      } else if (data.length > 0 && typeof data[0] === 'object') {
-        conversations = data.map((item: any) => {
-          const rawId = item.conversationId || item.id;
-          const id = (typeof rawId === 'object' && rawId !== null && rawId.id)
-            ? String(rawId.id)
-            : String(rawId);
-
-          return {
-            id,
-            title: item.title,
-            updated_at: item.updatedAt || item.updated_at
-          };
-        });
-      } else {
-        conversations = [];
-      }
-    } else if (data?.conversation_ids && Array.isArray(data.conversation_ids)) {
-      // Old wrapper format
-      conversations = data.conversation_ids.map((id: string) => ({ id, title: 'Chat' }));
-    } else if (data?.conversations && Array.isArray(data.conversations)) {
-      // New wrapper format
-      conversations = data.conversations.map((item: any) => {
-        const rawId = item.conversationId || item.id;
-        const id = (typeof rawId === 'object' && rawId !== null && rawId.id)
-          ? String(rawId.id)
-          : String(rawId);
-
-        return {
-          id,
-          title: item.title,
-          updated_at: item.updatedAt || item.updated_at
-        };
-      });
+    if (items && items.length > 0) {
+      conversations = typeof items[0] === 'string'
+        ? items.map((id: string) => ({ id, title: 'Chat' }))
+        : items.map(parseItem);
     }
 
-    console.info('[CHAT TRACE][AgentsClient] listConversations:parsed', {
-      userId,
-      count: conversations.length,
-      ids: conversations.map((item) => item.id),
-    });
     this.logDebug('listConversations:success', { userId, count: conversations.length });
     return conversations;
   }

--- a/apps/miniapp/src/features/lending/useLendingData.ts
+++ b/apps/miniapp/src/features/lending/useLendingData.ts
@@ -11,6 +11,7 @@ export const useLendingData = () => {
   const [userPosition, setUserPosition] = useState<LendingAccountPositionsResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [dataStale, setDataStale] = useState(false);
   const [lastFetchTime, setLastFetchTime] = useState<number>(0);
   const hasInitializedRef = useRef(false);
   const lastFetchTimeRef = useRef(0);
@@ -28,7 +29,7 @@ export const useLendingData = () => {
     }
 
     const run = (async () => {
-      setLoading(true);
+      setLoading(tokens.length === 0);
       setError(null);
 
       try {
@@ -87,8 +88,12 @@ export const useLendingData = () => {
         const fetchedAt = Date.now();
         lastFetchTimeRef.current = fetchedAt;
         setLastFetchTime(fetchedAt);
+        setDataStale(false);
       } catch (err) {
         console.error('[LENDING] Error fetching data:', err);
+        if (tokens.length > 0) {
+          setDataStale(true);
+        }
         setError(err instanceof Error ? err.message : 'Failed to load lending data');
       } finally {
         setLoading(false);
@@ -133,6 +138,7 @@ export const useLendingData = () => {
     tokens,
     userPosition,
     loading,
+    dataStale,
     error,
     refresh,
     clearCacheAndRefresh,

--- a/apps/miniapp/src/features/staking/baseApi.ts
+++ b/apps/miniapp/src/features/staking/baseApi.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useActiveAccount } from 'thirdweb/react';
+import { generateTraceId } from '@/shared/lib/fetchWithAuth';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -98,7 +99,7 @@ export class BaseStakingApiClient {
     const timer = setTimeout(() => controller.abort(), 15000);
     try {
       const res = await fetch(url, {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Trace-Id': generateTraceId() },
         signal: controller.signal,
         ...init,
       });

--- a/apps/miniapp/src/features/staking/baseApi.ts
+++ b/apps/miniapp/src/features/staking/baseApi.ts
@@ -171,7 +171,7 @@ export class BaseStakingApiClient {
     slippageBps?: number;
   }): Promise<BaseTransactionBundle> {
     if (!this.userAddress) throw new Error('Wallet not connected');
-    const res = await this.fetchJson<{ bundle: { steps: BaseTxStep[]; totalSteps: number; summary?: string }; metadata?: unknown }>('/staking/prepare-enter', {
+    const res = await this.fetchJson<{ bundle: { steps: BaseTxStep[]; totalSteps: number; summary?: string }; metadata?: Record<string, unknown> }>('/staking/prepare-enter', {
       method: 'POST',
       body: JSON.stringify({
         userAddress: this.userAddress,
@@ -185,14 +185,14 @@ export class BaseStakingApiClient {
       steps: res.bundle.steps,
       totalSteps: res.bundle.totalSteps,
       poolId: params.poolId,
-      poolName: '',
+      poolName: (res.metadata as Record<string, unknown>)?.poolName as string ?? params.poolId,
       action: 'enter',
     };
   }
 
   async prepareExit(poolId: string): Promise<BaseTransactionBundle> {
     if (!this.userAddress) throw new Error('Wallet not connected');
-    const res = await this.fetchJson<{ bundle: { steps: BaseTxStep[]; totalSteps: number; summary?: string }; metadata?: unknown }>('/staking/prepare-exit', {
+    const res = await this.fetchJson<{ bundle: { steps: BaseTxStep[]; totalSteps: number; summary?: string }; metadata?: Record<string, unknown> }>('/staking/prepare-exit', {
       method: 'POST',
       body: JSON.stringify({
         userAddress: this.userAddress,
@@ -203,14 +203,14 @@ export class BaseStakingApiClient {
       steps: res.bundle.steps,
       totalSteps: res.bundle.totalSteps,
       poolId,
-      poolName: '',
+      poolName: (res.metadata as Record<string, unknown>)?.poolName as string ?? poolId,
       action: 'exit',
     };
   }
 
   async prepareClaim(poolId: string): Promise<BaseTransactionBundle> {
     if (!this.userAddress) throw new Error('Wallet not connected');
-    const res = await this.fetchJson<{ bundle: { steps: BaseTxStep[]; totalSteps: number }; metadata?: unknown }>('/staking/prepare-claim', {
+    const res = await this.fetchJson<{ bundle: { steps: BaseTxStep[]; totalSteps: number }; metadata?: Record<string, unknown> }>('/staking/prepare-claim', {
       method: 'POST',
       body: JSON.stringify({
         userAddress: this.userAddress,
@@ -221,7 +221,7 @@ export class BaseStakingApiClient {
       steps: res.bundle.steps,
       totalSteps: res.bundle.totalSteps,
       poolId,
-      poolName: '',
+      poolName: (res.metadata as Record<string, unknown>)?.poolName as string ?? poolId,
       action: 'claim',
     };
   }

--- a/apps/miniapp/src/features/staking/useBaseStakingData.ts
+++ b/apps/miniapp/src/features/staking/useBaseStakingData.ts
@@ -14,6 +14,7 @@ export const useBaseStakingData = () => {
   const [apr, setApr] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [dataStale, setDataStale] = useState(false);
   const [lastFetchTime, setLastFetchTime] = useState(0);
   const lastFetchRef = useRef(0);
   const lastApiRef = useRef(api);
@@ -34,7 +35,7 @@ export const useBaseStakingData = () => {
       const now = Date.now();
       if (!force && now - lastFetchRef.current < MIN_FETCH_INTERVAL) return;
 
-      setLoading(true);
+      setLoading(positionsRef.current.length === 0);
       setError(null);
       try {
         // Fetch protocol info first — this doesn't need a wallet
@@ -61,8 +62,12 @@ export const useBaseStakingData = () => {
         }
         lastFetchRef.current = now;
         setLastFetchTime(now);
+        setDataStale(false);
       } catch (err) {
-        // Don't reset existing data on error
+        // Don't reset existing data on error — mark as stale instead
+        if (positionsRef.current.length > 0) {
+          setDataStale(true);
+        }
         setError(err instanceof Error ? err.message : 'Failed to load Base staking data');
       } finally {
         setLoading(false);
@@ -83,6 +88,7 @@ export const useBaseStakingData = () => {
     protocolInfo,
     apr,
     loading,
+    dataStale,
     error,
     refresh,
     lastFetchTime,

--- a/apps/miniapp/src/features/swap/api.ts
+++ b/apps/miniapp/src/features/swap/api.ts
@@ -13,6 +13,7 @@ import {
   StatusResponseSchema,
   validateResponse,
 } from '@/shared/lib/responseSchemas';
+import { generateTraceId } from '@/shared/lib/fetchWithAuth';
 
 export class SwapApiError extends Error {
   readonly url: string;
@@ -139,14 +140,15 @@ async function handleJsonResponse<T>(
 
 async function postJson<T>(path: string, body: unknown): Promise<T> {
   const url = `${baseUrl()}${path}`;
-  
+
   const authToken = localStorage.getItem('authToken');
-  const headers: Record<string, string> = { 'content-type': 'application/json' };
-  
-  
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'X-Trace-Id': generateTraceId(),
+  };
+
   if (authToken) {
     headers['Authorization'] = `Bearer ${authToken}`;
-  } else {
   }
   
   try {
@@ -168,7 +170,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
 
 async function getJson<T>(path: string): Promise<T> {
   const url = `${baseUrl()}${path}`;
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { 'X-Trace-Id': generateTraceId() };
   const authToken = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
   if (authToken) {
     headers['Authorization'] = `Bearer ${authToken}`;

--- a/apps/miniapp/src/features/swap/api.ts
+++ b/apps/miniapp/src/features/swap/api.ts
@@ -7,6 +7,12 @@ import type {
   UserFacingErrorDetails,
   UserFacingErrorResponse,
 } from './types';
+import {
+  QuoteResponseSchema,
+  PrepareResponseSchema,
+  StatusResponseSchema,
+  validateResponse,
+} from '@/shared/lib/responseSchemas';
 
 export class SwapApiError extends Error {
   readonly url: string;
@@ -180,7 +186,7 @@ async function getJson<T>(path: string): Promise<T> {
 }
 
 export const swapApi = {
-  quote(body: QuoteRequest) {
+  async quote(body: QuoteRequest) {
     // Runtime guardrails: prevent the common "wei passed as token" bug from silently producing nonsense quotes.
     try {
       const amount = String(body.amount ?? '').trim();
@@ -192,14 +198,17 @@ export const swapApi = {
       }
     } catch {}
     // baseUrl() already resolves to ".../swap" (or "/swap" on same origin)
-    return postJson<QuoteResponse>('/quote', body);
+    const raw = await postJson<QuoteResponse>('/quote', body);
+    return validateResponse(QuoteResponseSchema, raw, 'QuoteResponse').data;
   },
-  prepare(body: PrepareRequest) {
-    return postJson<PrepareResponse>('/tx', body);
+  async prepare(body: PrepareRequest) {
+    const raw = await postJson<PrepareResponse>('/tx', body);
+    return validateResponse(PrepareResponseSchema, raw, 'PrepareResponse').data;
   },
-  status(hash: string, chainId: number) {
+  async status(hash: string, chainId: number) {
     const qs = new URLSearchParams({ chainId: String(chainId) }).toString();
-    return getJson<StatusResponse>(`/status/${hash}?${qs}`);
+    const raw = await getJson<StatusResponse>(`/status/${hash}?${qs}`);
+    return validateResponse(StatusResponseSchema, raw, 'StatusResponse').data;
   },
   pairs() {
     return getJson<{ pairs: import('./types').SwapPair[] }>('/pairs');

--- a/apps/miniapp/src/features/yield/api.ts
+++ b/apps/miniapp/src/features/yield/api.ts
@@ -15,6 +15,15 @@ import type {
   PreparedTransaction,
   TransactionExecutionStatus,
 } from './types';
+import {
+  YieldPoolSchema,
+  PoolProtocolInfoSchema,
+  UserPositionSchema,
+  PortfolioSchema,
+  YieldPrepareResponseSchema,
+  validateResponse,
+} from '@/shared/lib/responseSchemas';
+import { z } from 'zod';
 
 type SwitchChainFn = (chain: ReturnType<typeof defineChain>) => Promise<void>;
 
@@ -288,22 +297,38 @@ class YieldApiClient {
 
   async getPools(): Promise<YieldPool[]> {
     const data = await this.fetchJson<{ pools: YieldPool[] }>(API_ENDPOINTS.POOLS);
-    return data.pools;
+    const { data: validated } = validateResponse(
+      z.object({ pools: z.array(YieldPoolSchema) }),
+      data,
+      'YieldPools',
+    );
+    return validated.pools;
   }
 
   async getProtocolInfo(): Promise<{ pools: PoolProtocolInfo[]; updatedAt: string }> {
-    return this.fetchJson(API_ENDPOINTS.PROTOCOL_INFO);
+    const data = await this.fetchJson<{ pools: PoolProtocolInfo[]; updatedAt: string }>(API_ENDPOINTS.PROTOCOL_INFO);
+    return validateResponse(
+      z.object({ pools: z.array(PoolProtocolInfoSchema), updatedAt: z.string() }),
+      data,
+      'ProtocolInfo',
+    ).data;
   }
 
   async getPosition(userAddress: string): Promise<UserPosition[]> {
     const data = await this.fetchJson<{ positions: UserPosition[] }>(
       `${API_ENDPOINTS.POSITION}/${userAddress}`,
     );
-    return data.positions;
+    const { data: validated } = validateResponse(
+      z.object({ positions: z.array(UserPositionSchema) }),
+      data,
+      'UserPositions',
+    );
+    return validated.positions;
   }
 
   async getPortfolio(userAddress: string): Promise<Portfolio> {
-    return this.fetchJson<Portfolio>(`${API_ENDPOINTS.PORTFOLIO}/${userAddress}`);
+    const raw = await this.fetchJson<Portfolio>(`${API_ENDPOINTS.PORTFOLIO}/${userAddress}`);
+    return validateResponse(PortfolioSchema, raw, 'Portfolio').data;
   }
 
   // ── Transaction Preparation ──
@@ -315,10 +340,11 @@ class YieldApiClient {
     amountB: string;
     slippageBps?: number;
   }): Promise<YieldPrepareResponse> {
-    return this.fetchJson<YieldPrepareResponse>(API_ENDPOINTS.PREPARE_ENTER, {
+    const raw = await this.fetchJson<YieldPrepareResponse>(API_ENDPOINTS.PREPARE_ENTER, {
       method: 'POST',
       body: JSON.stringify(params),
     });
+    return validateResponse(YieldPrepareResponseSchema, raw, 'YieldPrepareEnter').data;
   }
 
   async prepareExit(params: {
@@ -326,20 +352,22 @@ class YieldApiClient {
     poolId: string;
     amount?: string;
   }): Promise<YieldPrepareResponse> {
-    return this.fetchJson<YieldPrepareResponse>(API_ENDPOINTS.PREPARE_EXIT, {
+    const raw = await this.fetchJson<YieldPrepareResponse>(API_ENDPOINTS.PREPARE_EXIT, {
       method: 'POST',
       body: JSON.stringify(params),
     });
+    return validateResponse(YieldPrepareResponseSchema, raw, 'YieldPrepareExit').data;
   }
 
   async prepareClaim(params: {
     userAddress: string;
     poolId: string;
   }): Promise<YieldPrepareResponse> {
-    return this.fetchJson<YieldPrepareResponse>(API_ENDPOINTS.PREPARE_CLAIM, {
+    const raw = await this.fetchJson<YieldPrepareResponse>(API_ENDPOINTS.PREPARE_CLAIM, {
       method: 'POST',
       body: JSON.stringify(params),
     });
+    return validateResponse(YieldPrepareResponseSchema, raw, 'YieldPrepareClaim').data;
   }
 
   // ── Transaction Tracking ──

--- a/apps/miniapp/src/features/yield/useYieldData.ts
+++ b/apps/miniapp/src/features/yield/useYieldData.ts
@@ -60,6 +60,7 @@ export function useYieldData() {
   const [loading, setLoading] = useState(poolsCache == null);
   const [userLoading, setUserLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [portfolioStale, setPortfolioStale] = useState(false);
 
   const lastFetchRef = useRef(0);
   const poolsRef = useRef<YieldPoolWithAPR[]>(poolsCache?.pools ?? []);
@@ -183,7 +184,9 @@ export function useYieldData() {
         ]);
 
         let nextPortfolio = port;
-        // Guard against transient RPC failures that sometimes return "0" for all token balances.
+        let isStale = false;
+
+        // Detect transient RPC failures that return "0" for all token balances.
         if (nextPortfolio?.walletBalances) {
           const values = Object.values(nextPortfolio.walletBalances);
           const allZero = values.length > 0 && values.every((value) => {
@@ -194,22 +197,13 @@ export function useYieldData() {
           if (allZero) {
             const cachedNonZero = lastNonZeroPortfolioByUser.get(userAddress);
             if (cachedNonZero) {
+              console.warn('[YIELD] All-zero balances detected, using last known portfolio (stale)');
               nextPortfolio = cachedNonZero;
+              isStale = true;
             }
-            try {
-              const retried = await yieldApi.getPortfolio(userAddress);
-              const retriedValues = Object.values(retried.walletBalances ?? {});
-              const hasNonZero = retriedValues.some((value) => {
-                const numeric = Number.parseFloat(value);
-                return Number.isFinite(numeric) && numeric > 0;
-              });
-              if (hasNonZero) {
-                nextPortfolio = retried;
-                lastNonZeroPortfolioByUser.set(userAddress, retried);
-              }
-            } catch {
-              // Keep original response if retry fails.
-            }
+            // No hidden retry — surface the staleness to the UI instead
+          } else {
+            lastNonZeroPortfolioByUser.set(userAddress, nextPortfolio);
           }
         } else if (nextPortfolio) {
           const values = Object.values(nextPortfolio.walletBalances ?? {});
@@ -221,6 +215,8 @@ export function useYieldData() {
             lastNonZeroPortfolioByUser.set(userAddress, nextPortfolio);
           }
         }
+
+        setPortfolioStale(isStale);
 
         setPositions(pos);
         setPortfolio(nextPortfolio);
@@ -275,6 +271,7 @@ export function useYieldData() {
     protocolInfo,
     positions,
     portfolio,
+    portfolioStale,
     loading,
     userLoading,
     error,

--- a/apps/miniapp/src/shared/config/demo.ts
+++ b/apps/miniapp/src/shared/config/demo.ts
@@ -1,0 +1,36 @@
+/**
+ * Demo mode configuration for deterministic UI output.
+ * Aligns with backend config/demo.ts canonical flow.
+ */
+
+export const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
+
+/** Default token pair for demo swap flow (Base chain) */
+export const DEMO_SWAP_DEFAULTS = {
+  fromToken: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // ETH
+  toToken: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',   // USDC on Base
+  amount: '0.001',
+  chainId: 8453,
+} as const;
+
+/** Default pool for demo staking flow */
+export const DEMO_STAKING_DEFAULTS = {
+  poolId: 'vAMM-WETH/USDC',
+  amountA: '0.001',
+  amountB: '2.0',
+  slippageBps: 200, // 2% for demo stability
+} as const;
+
+/** Wider timeouts for demo environments (free RPCs are slower) */
+export const DEMO_TIMEOUTS = {
+  apiRequestMs: 20_000,
+  walletConfirmMs: 90_000,
+} as const;
+
+/**
+ * Check if app is running in demo mode.
+ * UI should use this to show demo-safe defaults and controlled error messages.
+ */
+export function isDemoMode(): boolean {
+  return DEMO_MODE;
+}

--- a/apps/miniapp/src/shared/contracts/v1/index.ts
+++ b/apps/miniapp/src/shared/contracts/v1/index.ts
@@ -1,0 +1,179 @@
+/**
+ * Versioned response contracts — v1
+ *
+ * Canonical TypeScript types that mirror backend API schemas.
+ * Both API clients and React components should reference these types.
+ * Zod runtime validation lives in shared/lib/responseSchemas.ts.
+ */
+
+export const SCHEMA_VERSION = 'v1' as const;
+
+// ── Error Contract ────────────────────────────────────────────────
+
+export interface ErrorContract {
+  code: string;
+  message: string;
+  traceId?: string;
+}
+
+export interface ErrorResponseContract {
+  success: false;
+  error: ErrorContract;
+}
+
+// ── Execution Contract ────────────────────────────────────────────
+
+export interface PreparedTransactionContract {
+  to: string;
+  data: string;
+  value: string;
+  chainId: number;
+  description?: string;
+}
+
+export interface TransactionBundleContract {
+  steps: PreparedTransactionContract[];
+  totalSteps: number;
+  summary: string;
+}
+
+export interface ExecutionResultContract {
+  transactionHash: string;
+  confirmed: boolean;
+  source?: 'wallet' | 'recovered';
+}
+
+// ── Quote Contract ────────────────────────────────────────────────
+
+export interface QuoteContract {
+  success: boolean;
+  quote?: {
+    fromChainId: number;
+    toChainId: number;
+    fromToken: string;
+    toToken: string;
+    amount: string;
+    estimatedReceiveAmount: string;
+    estimatedDuration?: number;
+    exchangeRate?: string;
+    fees?: {
+      bridgeFee?: string;
+      gasFee?: string;
+      totalFee?: string;
+      totalFeeUsd?: string;
+    };
+    provider?: string;
+  };
+  message?: string;
+}
+
+// ── Prepare Contract ──────────────────────────────────────────────
+
+export interface PrepareContract {
+  prepared?: {
+    transactions?: Array<{
+      to: string;
+      data: string;
+      value?: string | number | null;
+      chainId: number;
+      gasLimit?: string | number | null;
+    }>;
+    steps?: Array<{
+      name?: string;
+      chainId: number;
+      transactions: Array<{
+        to: string;
+        data: string;
+        value?: string | number | null;
+        chainId: number;
+      }>;
+    }>;
+    metadata?: Record<string, unknown>;
+  };
+  provider?: string;
+  message?: string;
+}
+
+// ── Portfolio Contract ────────────────────────────────────────────
+
+export interface TokenInfoContract {
+  symbol: string;
+  address: string;
+  decimals: number;
+}
+
+export interface PortfolioAssetContract {
+  poolId: string;
+  poolName: string;
+  tokenA: TokenInfoContract & { balance: string };
+  tokenB: TokenInfoContract & { balance: string };
+  lpStaked: string;
+  pendingRewards: string;
+  rewardTokenSymbol: string;
+}
+
+export interface PortfolioContract {
+  userAddress: string;
+  totalPositions: number;
+  assets: PortfolioAssetContract[];
+  walletBalances: Record<string, string>;
+}
+
+// ── Yield / Staking Contract ──────────────────────────────────────
+
+export interface YieldPoolContract {
+  id: string;
+  name: string;
+  tokenA: TokenInfoContract;
+  tokenB: TokenInfoContract;
+  stable: boolean;
+  poolAddress: string;
+  gaugeAddress: string;
+  gaugeAlive: boolean;
+  rewardToken: TokenInfoContract;
+  totalStaked: string;
+  rewardRate: string;
+}
+
+export interface UserPositionContract {
+  poolId: string;
+  poolName: string;
+  poolAddress: string;
+  gaugeAddress: string;
+  tokenA: TokenInfoContract;
+  tokenB: TokenInfoContract;
+  stable: boolean;
+  stakedBalance: string;
+  walletLpBalance: string;
+  earnedRewards: string;
+  rewardToken: TokenInfoContract;
+}
+
+// ── Lending Contract ──────────────────────────────────────────────
+
+export interface LendingTokenContract {
+  symbol: string;
+  address: string;
+  qTokenAddress: string;
+  decimals: number;
+  supplyAPY: string;
+  borrowAPY: string;
+  collateralFactor: string;
+  availableLiquidity: string;
+  icon?: string;
+}
+
+export interface LendingPositionContract {
+  supplied: Array<{
+    symbol: string;
+    qTokenAddress: string;
+    underlyingBalance: string;
+    qTokenBalance: string;
+  }>;
+  borrowed: Array<{
+    symbol: string;
+    qTokenAddress: string;
+    borrowBalance: string;
+  }>;
+  healthFactor: string | null;
+}

--- a/apps/miniapp/src/shared/lib/ErrorBoundary.tsx
+++ b/apps/miniapp/src/shared/lib/ErrorBoundary.tsx
@@ -2,36 +2,72 @@ import React from 'react';
 
 interface ErrorBoundaryState {
   error: unknown;
+  hasError: boolean;
 }
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
+  /** Label shown in the fallback UI (e.g. "Swap", "Portfolio") */
+  section?: string;
+  /** Optional custom fallback component */
+  fallback?: React.ReactNode;
 }
 
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { error: null };
+    this.state = { error: null, hasError: false };
   }
 
   static getDerivedStateFromError(error: unknown) {
-    return { error };
+    return { error, hasError: true };
   }
 
   override componentDidCatch(error: unknown, info: React.ErrorInfo) {
-    const pre = document.createElement('pre');
-    pre.style.cssText = 'color:#f33;padding:12px;white-space:pre-wrap';
-    pre.textContent = 'Render error: ' + (error instanceof Error ? error.stack : String(error)) + '\n' + (info?.componentStack || '');
-    document.body.appendChild(pre);
+    console.error(
+      `[ErrorBoundary${this.props.section ? `:${this.props.section}` : ''}]`,
+      error instanceof Error ? error.message : String(error),
+      info?.componentStack,
+    );
   }
 
+  private handleRetry = () => {
+    this.setState({ error: null, hasError: false });
+  };
+
   override render(): React.ReactNode {
-    if (this.state.error) {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      const section = this.props.section ?? 'This section';
       return React.createElement(
         'div',
-        { style: { padding: 16, color: '#f33', fontFamily: 'system-ui' } },
-        'Render error: ',
-        String(this.state.error),
+        {
+          style: {
+            padding: 24,
+            textAlign: 'center' as const,
+            fontFamily: 'system-ui, -apple-system, sans-serif',
+          },
+        },
+        React.createElement('p', {
+          style: { color: '#a1a1aa', fontSize: 14, marginBottom: 12 },
+        }, `${section} ran into an issue. Please try again.`),
+        React.createElement(
+          'button',
+          {
+            onClick: this.handleRetry,
+            style: {
+              padding: '8px 20px',
+              borderRadius: 8,
+              border: '1px solid #3f3f46',
+              background: '#18181b',
+              color: '#fafafa',
+              fontSize: 14,
+              cursor: 'pointer',
+            },
+          },
+          'Try again',
+        ),
       );
     }
     return this.props.children;

--- a/apps/miniapp/src/shared/lib/errorMapper.ts
+++ b/apps/miniapp/src/shared/lib/errorMapper.ts
@@ -27,14 +27,32 @@ const ERROR_MAP: Record<string, string> = {
   'TOO_MANY_REQUESTS': 'Too many requests. Please wait a moment.',
 
   // Network
-  'RPC_ERROR': 'Network error. The blockchain node is temporarily unavailable.',
+  'RPC_ERROR': 'Network is busy. Please try again in a moment.',
   'NETWORK_ERROR': 'Connection error. Please check your internet connection.',
   'SERVICE_UNAVAILABLE': 'Service is temporarily unavailable. Please try again later.',
   'TIMEOUT': 'Request timed out. Please try again.',
+  'EXECUTION_TIMEOUT': 'Request timed out. The network may be congested — please try again.',
 
   // Validation contract
   'TAX_TRANSFER_FAILED': 'Validation fee transfer failed. Please try again.',
   'NO_AVAX_SENT': 'No AVAX was sent with the transaction.',
+
+  // Staking / Liquidity
+  'POOL_NOT_FOUND': 'Pool not found. It may have been removed or is temporarily unavailable.',
+  'GAUGE_NOT_FOUND': 'Staking gauge not found for this pool.',
+  'NO_LP_POSITION': 'You don\'t have a position in this pool.',
+  'INSUFFICIENT_LP_BALANCE': 'Insufficient LP balance for this withdrawal amount.',
+  'NO_LIQUIDITY': 'Not enough liquidity available. Try a smaller amount.',
+  'NO_REWARDS': 'No rewards available to claim yet.',
+  'EXECUTOR_NOT_CONFIGURED': 'Service configuration error. Please try again later.',
+
+  // DCA
+  'ORDER_NOT_FOUND': 'DCA order not found.',
+  'ORDER_UNAUTHORIZED': 'This order does not belong to your wallet.',
+  'ORDER_INACTIVE': 'This order is already cancelled.',
+
+  // Queue / Rate limiting
+  'QUEUE_FULL': 'Too many pending requests. Please wait for current operations to complete.',
 
   // Lending specific
   'HEALTH_FACTOR_TOO_LOW': 'This operation would put your position at risk of liquidation.',
@@ -80,7 +98,9 @@ export function mapError(error: unknown, fallback?: string): string {
     const status = (error as any).status;
     if (status === 401 || status === 403) return ERROR_MAP.UNAUTHORIZED;
     if (status === 429) return ERROR_MAP.RATE_LIMITED;
+    if (status === 502) return ERROR_MAP.RPC_ERROR;
     if (status === 503) return ERROR_MAP.SERVICE_UNAVAILABLE;
+    if (status === 504) return ERROR_MAP.EXECUTION_TIMEOUT;
   }
 
   return fallback || 'Something went wrong. Please try again.';

--- a/apps/miniapp/src/shared/lib/fetchWithAuth.ts
+++ b/apps/miniapp/src/shared/lib/fetchWithAuth.ts
@@ -12,6 +12,17 @@
 
 const AUTH_API_BASE = (typeof process !== 'undefined' ? process.env.VITE_AUTH_API_BASE || '' : '').replace(/\/+$/, '');
 
+/**
+ * Generate a trace ID for request tracing across frontend and backend.
+ * Uses crypto.randomUUID when available, falls back to Math.random.
+ */
+export function generateTraceId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 let isRefreshing = false;
 let refreshPromise: Promise<string | null> | null = null;
 
@@ -84,8 +95,15 @@ export async function fetchWithAuth(
 ): Promise<Response> {
   const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
 
+  // Inject trace ID for request correlation
+  const headers = new Headers(init.headers);
+  if (!headers.has('X-Trace-Id')) {
+    headers.set('X-Trace-Id', generateTraceId());
+  }
+  const tracedInit = { ...init, headers };
+
   // First attempt
-  const requestInit = token ? injectAuthHeader(init, token) : init;
+  const requestInit = token ? injectAuthHeader(tracedInit, token) : tracedInit;
   const response = await fetch(input, requestInit);
 
   if (response.status !== 401 || !token) {
@@ -102,6 +120,6 @@ export async function fetchWithAuth(
     return response; // return original 401
   }
 
-  // Retry with new token
-  return fetch(input, injectAuthHeader(init, newToken));
+  // Retry with new token (keep same trace ID)
+  return fetch(input, injectAuthHeader(tracedInit, newToken));
 }

--- a/apps/miniapp/src/shared/lib/responseSchemas.ts
+++ b/apps/miniapp/src/shared/lib/responseSchemas.ts
@@ -1,0 +1,219 @@
+/**
+ * Zod schemas for critical API response types.
+ * Used to validate backend responses at runtime before passing to React state.
+ *
+ * Usage in API clients:
+ *   const data = await res.json();
+ *   const parsed = QuoteResponseSchema.safeParse(data);
+ *   if (!parsed.success) { console.warn('Invalid quote response', parsed.error); }
+ */
+import { z } from 'zod';
+
+// ── Shared Primitives ──────────────────────────────────────────────
+
+const TokenInfoSchema = z.object({
+  symbol: z.string(),
+  address: z.string(),
+  decimals: z.number(),
+});
+
+const PreparedTransactionSchema = z.object({
+  to: z.string(),
+  data: z.string(),
+  value: z.string(),
+  chainId: z.number(),
+  description: z.string().optional(),
+});
+
+const TransactionBundleSchema = z.object({
+  steps: z.array(PreparedTransactionSchema),
+  totalSteps: z.number(),
+  summary: z.string(),
+});
+
+// ── Error Response ─────────────────────────────────────────────────
+
+export const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+// ── Swap ───────────────────────────────────────────────────────────
+
+export const QuoteResponseSchema = z.object({
+  success: z.boolean(),
+  quote: z.object({
+    fromChainId: z.number(),
+    toChainId: z.number(),
+    fromToken: z.string(),
+    toToken: z.string(),
+    amount: z.string(),
+    estimatedReceiveAmount: z.string(),
+    estimatedDuration: z.number().optional(),
+    exchangeRate: z.string().optional(),
+    fees: z.object({
+      bridgeFee: z.string().optional(),
+      gasFee: z.string().optional(),
+      totalFee: z.string().optional(),
+      totalFeeUsd: z.string().optional(),
+    }).optional(),
+    provider: z.string().optional(),
+  }).optional(),
+  message: z.string().optional(),
+});
+
+export const PrepareResponseSchema = z.object({
+  prepared: z.object({
+    transactions: z.array(z.object({
+      to: z.string(),
+      data: z.string(),
+      value: z.union([z.string(), z.number(), z.null()]).optional(),
+      chainId: z.number(),
+      gasLimit: z.union([z.string(), z.number(), z.null()]).optional(),
+    })).optional(),
+    steps: z.array(z.object({
+      name: z.string().optional(),
+      chainId: z.number(),
+      transactions: z.array(z.object({
+        to: z.string(),
+        data: z.string(),
+        value: z.union([z.string(), z.number(), z.null()]).optional(),
+        chainId: z.number(),
+      })),
+    })).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  }).optional(),
+  provider: z.string().optional(),
+  message: z.string().optional(),
+});
+
+export const StatusResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.object({
+    status: z.string(),
+    transactionHash: z.string(),
+    chainId: z.number(),
+    userAddress: z.string().optional(),
+  }).optional(),
+});
+
+// ── Yield / Staking ────────────────────────────────────────────────
+
+export const YieldPoolSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  tokenA: TokenInfoSchema,
+  tokenB: TokenInfoSchema,
+  stable: z.boolean(),
+  poolAddress: z.string(),
+  gaugeAddress: z.string(),
+  gaugeAlive: z.boolean(),
+  rewardToken: TokenInfoSchema,
+  totalStaked: z.string(),
+  rewardRate: z.string(),
+});
+
+export const PoolProtocolInfoSchema = z.object({
+  poolId: z.string(),
+  poolName: z.string(),
+  poolAddress: z.string(),
+  gaugeAddress: z.string(),
+  stable: z.boolean(),
+  rewardRatePerSecond: z.string(),
+  totalStaked: z.string(),
+  estimatedAPR: z.string(),
+  totalLiquidityUsd: z.string().nullable().optional(),
+});
+
+export const UserPositionSchema = z.object({
+  poolId: z.string(),
+  poolName: z.string(),
+  poolAddress: z.string(),
+  gaugeAddress: z.string(),
+  tokenA: TokenInfoSchema,
+  tokenB: TokenInfoSchema,
+  stable: z.boolean(),
+  stakedBalance: z.string(),
+  walletLpBalance: z.string(),
+  earnedRewards: z.string(),
+  rewardToken: TokenInfoSchema,
+});
+
+export const PortfolioSchema = z.object({
+  userAddress: z.string(),
+  totalPositions: z.number(),
+  assets: z.array(z.object({
+    poolId: z.string(),
+    poolName: z.string(),
+    tokenA: TokenInfoSchema.extend({ balance: z.string() }),
+    tokenB: TokenInfoSchema.extend({ balance: z.string() }),
+    lpStaked: z.string(),
+    pendingRewards: z.string(),
+    rewardTokenSymbol: z.string(),
+  })),
+  walletBalances: z.record(z.string()),
+});
+
+export const YieldPrepareResponseSchema = z.object({
+  bundle: TransactionBundleSchema,
+  metadata: z.record(z.unknown()),
+});
+
+// ── Lending ────────────────────────────────────────────────────────
+
+export const LendingTokenSchema = z.object({
+  symbol: z.string(),
+  address: z.string(),
+  qTokenAddress: z.string(),
+  decimals: z.number(),
+  supplyAPY: z.string(),
+  borrowAPY: z.string(),
+  collateralFactor: z.string(),
+  availableLiquidity: z.string(),
+  icon: z.string().optional(),
+});
+
+export const LendingPositionSchema = z.object({
+  supplied: z.array(z.object({
+    symbol: z.string(),
+    qTokenAddress: z.string(),
+    underlyingBalance: z.string(),
+    qTokenBalance: z.string(),
+  })),
+  borrowed: z.array(z.object({
+    symbol: z.string(),
+    qTokenAddress: z.string(),
+    borrowBalance: z.string(),
+  })),
+  healthFactor: z.string().nullable(),
+});
+
+// ── Validation Helper ──────────────────────────────────────────────
+
+/**
+ * Validates a response against a Zod schema.
+ * On failure, logs a warning and returns the raw data (graceful degradation).
+ *
+ * @param schema  Zod schema to validate against
+ * @param data    Raw response data
+ * @param label   Label for the warning log (e.g. "QuoteResponse")
+ * @returns       Parsed data (typed) or raw data on validation failure
+ */
+export function validateResponse<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  label: string,
+): { data: T; valid: boolean } {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return { data: result.data, valid: true };
+  }
+
+  console.warn(
+    `[validateResponse] ${label} schema mismatch:`,
+    result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', '),
+  );
+  return { data: data as T, valid: false };
+}


### PR DESCRIPTION
## Summary

Frontend-backend alignment sprint: runtime validation, error resilience, request tracing, dead code cleanup, and versioned contracts.

### Runtime Validation (H7, R1)
- **Zod response schemas** (`shared/lib/responseSchemas.ts`): schemas for Quote, Prepare, Status, YieldPool, PoolProtocolInfo, UserPosition, Portfolio, YieldPrepare, LendingToken, LendingPosition
- **`validateResponse()` helper**: graceful degradation — logs warning on mismatch, returns raw data instead of throwing
- **Integrated into API clients**: `swap/api.ts` (quote, prepare, status), `yield/api.ts` (pools, positions, portfolio, prepare enter/exit/claim), `staking/baseApi.ts`

### Error Resilience (R2, R3, R4)
- **ErrorBoundary** enhanced: section label, retry button, non-technical user-facing messages. Wrapped at app root via `providers.tsx`
- **Error mapper** expanded: 12 new error codes (EXECUTION_TIMEOUT, POOL_NOT_FOUND, GAUGE_NOT_FOUND, NO_LP_POSITION, etc.) + HTTP 502→RPC_ERROR, 504→EXECUTION_TIMEOUT mappings
- **Stale data flags**: `portfolioStale` in useYieldData, `dataStale` in useBaseStakingData and useLendingData — hooks preserve last-known data on failure, suppress loading flicker when cached data exists

### Fallback Logic Cleanup (H8)
- Removed hidden retry in `useYieldData.ts` that silently replaced all-zero portfolio responses
- `portfolioStale` flag surfaces staleness to UI instead of masking failures
- Audited `agentsClient.ts` `coerceResponse()` — confirmed clean (no stale data reuse)

### Request Tracing (R8)
- `generateTraceId()` utility (crypto.randomUUID with fallback)
- `fetchWithAuth.ts`: auto-injects `X-Trace-Id` header on every request
- `swap/api.ts`, `staking/baseApi.ts`: trace ID added to direct fetch calls

### Dead Code Cleanup (R5)
- `agentsClient.ts`: consolidated 3 duplicated output/data/result extraction blocks into loop, extracted `parseItem` helper for conversation ID normalization, replaced `[CHAT TRACE]` console.info with conditioned `logDebug()`

### Versioned Contracts (R6)
- `shared/contracts/v1/index.ts`: canonical TypeScript types mirroring backend schemas — Error, Quote, Prepare, Portfolio, Yield, Lending, ExecutionResult, TransactionBundle contracts with `SCHEMA_VERSION` constant

### Demo Mode (R7)
- `shared/config/demo.ts`: frontend demo defaults aligned with backend `config/demo.ts` — ETH→USDC swap, vAMM-WETH/USDC pool, 2% slippage, wider timeouts, `isDemoMode()` helper

### Bug Fix
- `staking/baseApi.ts`: fixed `poolName: ''` hardcoded in prepareEnter/Exit/Claim — now reads from `res.metadata.poolName`, falls back to `poolId`
