### PR TITLE
Fix Google auth window.open behavior in miniapp

### DIFF
--- a/apps/miniapp/src/shared/lib/__tests__/telegramWindowOpenShim.test.ts
+++ b/apps/miniapp/src/shared/lib/__tests__/telegramWindowOpenShim.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('installTelegramWindowOpenShim', () => {
+  const originalTelegram = (window as any).Telegram;
+  const originalOpen = window.open;
+
+  afterEach(() => {
+    (window as any).Telegram = originalTelegram;
+    window.open = originalOpen;
+    vi.resetModules();
+  });
+
+  it('does not override window.open when Telegram.WebApp is injected outside a real mini app context', async () => {
+    (window as any).Telegram = {
+      WebApp: {
+        version: '7.0',
+        initData: '',
+        openLink: vi.fn(),
+        openTelegramLink: vi.fn(),
+      },
+    };
+
+    const { installTelegramWindowOpenShim } = await import('../telegramWindowOpenShim');
+
+    installTelegramWindowOpenShim();
+
+    expect(window.open).toBe(originalOpen);
+  });
+
+  it("leaves generic https popups to the browser when running in a real Telegram mini app context", async () => {
+    const openLink = vi.fn();
+    const popup = {} as Window;
+    window.open = vi.fn(() => popup);
+    (window as any).Telegram = {
+      WebApp: {
+        version: "7.0",
+        initData: "query_id=test",
+        openLink,
+        openTelegramLink: vi.fn(),
+      },
+    };
+
+    const { installTelegramWindowOpenShim } = await import("../telegramWindowOpenShim");
+
+    installTelegramWindowOpenShim();
+    const result = window.open("https://accounts.google.com/o/oauth2/v2/auth", "_blank");
+
+    expect(result).toBe(popup);
+    expect(openLink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/miniapp/src/shared/lib/telegramWindowOpenShim.ts
+++ b/apps/miniapp/src/shared/lib/telegramWindowOpenShim.ts
@@ -1,43 +1,35 @@
 /**
  * Telegram Mini App window.open shim.
  *
- * Problem: Inside Telegram's iOS webview, window.open() is frequently blocked
- * or opens a non-functional tab. WalletConnect / Reown AppKit / Thirdweb's
- * wallet connectors call window.open(href, '_self') or similar to redirect
- * to wallet apps via deep links (wc:, metamask:, trust:, etc.), which then
- * silently fail and leave the user staring at a spinner.
- *
- * Fix: Override window.open. When the target URL looks like a wallet deep link
- * or any scheme the Telegram webview can't handle, route it through
- * Telegram.WebApp.openLink (external browser) or openTelegramLink (tg://).
- *
- * Call this once at app boot, BEFORE any wallet SDK initializes.
- *
- * References:
- * - https://github.com/reown-com/appkit/issues/1530
- * - https://docs.reown.com/appkit/features/telegram-mini-apps
+ * Inside Telegram webviews, wallet deep links opened with window.open can fail or
+ * leave the user on a spinner. This shim only installs in a real Telegram Mini App
+ * context and only intercepts Telegram links plus known wallet deep links.
+ * Generic HTTP(S) links must keep the browser popup behavior because OAuth providers
+ * such as Google rely on receiving a real Window object from window.open().
  */
 
 type TgWebApp = {
+  initData?: string;
   openLink?: (url: string, options?: { try_instant_view?: boolean }) => void;
   openTelegramLink?: (url: string) => void;
   platform?: string;
+  version?: string;
 };
 
 const WALLET_SCHEMES = [
-  'wc:',
-  'metamask:',
-  'https://metamask.app.link',
-  'trust:',
-  'https://link.trustwallet.com',
-  'bitkeep:',
-  'https://bkcode.vip',
-  'https://bitkeep.jnj.mobi',
-  'core:',
-  'https://core.app',
-  'rainbow:',
-  'https://rnbwapp.com',
-  'ledgerlive:',
+  "wc:",
+  "metamask:",
+  "https://metamask.app.link",
+  "trust:",
+  "https://link.trustwallet.com",
+  "bitkeep:",
+  "https://bkcode.vip",
+  "https://bitkeep.jnj.mobi",
+  "core:",
+  "https://core.app",
+  "rainbow:",
+  "https://rnbwapp.com",
+  "ledgerlive:",
 ];
 
 function isWalletDeepLink(url: string): boolean {
@@ -46,20 +38,69 @@ function isWalletDeepLink(url: string): boolean {
 }
 
 function getWebApp(): TgWebApp | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === "undefined") return null;
   return (window as any).Telegram?.WebApp ?? null;
+}
+
+function hasRealTelegramMiniAppSignal(webApp: TgWebApp): boolean {
+  if (typeof window === "undefined") return false;
+
+  const initData = typeof webApp.initData === "string" ? webApp.initData.trim() : "";
+  if (initData.length > 0) return true;
+
+  const search = window.location?.search ?? "";
+  const hasTgParams = /tgWebApp/i.test(search);
+  const overrideParam = /(?:^|[?&])tma=(1|true)(?:&|$)/i.test(search);
+  const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+  const hasTelegramUA = /Telegram/i.test(userAgent);
+  const referrer = typeof document !== "undefined" ? document.referrer : "";
+  const fromTelegramWeb = /web\.telegram\.(org|me)/i.test(referrer);
+  const isIframe = window.top !== window;
+  const host = window.location.hostname.toLowerCase();
+
+  if (/^web\.telegram\.(org|me)$/i.test(host)) return true;
+  if ((hasTgParams || overrideParam) && (hasTelegramUA || fromTelegramWeb || isIframe)) return true;
+  if (isIframe && typeof webApp.version === "string" && (hasTelegramUA || fromTelegramWeb)) return true;
+
+  return false;
 }
 
 let installed = false;
 
 export function installTelegramWindowOpenShim(): void {
   if (installed) return;
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
   const webApp = getWebApp();
-  if (!webApp) return; // not running inside Telegram — no shim needed
+  if (!webApp || !hasRealTelegramMiniAppSignal(webApp)) return;
 
   const originalOpen = window.open.bind(window);
+
+  const callTelegramLinkOpener = (open: ((url: string, options?: { try_instant_view?: boolean }) => void) | undefined, href: string) => {
+    if (!open) return originalOpen(href, "_blank");
+
+    const shimmedOpen = window.open;
+    try {
+      window.open = originalOpen;
+      open(href, { try_instant_view: false });
+      return null;
+    } finally {
+      window.open = shimmedOpen;
+    }
+  };
+
+  const callTelegramInternalOpener = (href: string) => {
+    if (!webApp.openTelegramLink) return originalOpen(href, "_blank");
+
+    const shimmedOpen = window.open;
+    try {
+      window.open = originalOpen;
+      webApp.openTelegramLink(href);
+      return null;
+    } finally {
+      window.open = shimmedOpen;
+    }
+  };
 
   (window as any).open = (
     url?: string | URL,
@@ -67,37 +108,24 @@ export function installTelegramWindowOpenShim(): void {
     features?: string,
   ): Window | null => {
     try {
-      const href = typeof url === 'string' ? url : url?.toString() ?? '';
+      const href = typeof url === "string" ? url : url?.toString() ?? "";
       if (!href) return originalOpen(url as any, target, features);
 
-      // tg:// and t.me links → stay inside Telegram
-      if (href.startsWith('tg://') || href.startsWith('https://t.me/')) {
-        webApp.openTelegramLink?.(href);
-        return null;
+      if (href.startsWith("tg://") || href.startsWith("https://t.me/")) {
+        return callTelegramInternalOpener(href);
       }
 
-      // Wallet deep links → hand to Telegram so iOS actually follows them
       if (isWalletDeepLink(href)) {
-        webApp.openLink?.(href, { try_instant_view: false });
-        return null;
-      }
-
-      // Generic https:// — let Telegram route it externally, which is
-      // more reliable than window.open inside the webview
-      if (href.startsWith('https://') || href.startsWith('http://')) {
-        webApp.openLink?.(href, { try_instant_view: false });
-        return null;
+        return callTelegramLinkOpener(webApp.openLink, href);
       }
 
       return originalOpen(url as any, target, features);
     } catch (err) {
-      // If anything goes wrong, fall back to the original
-      console.warn('[TgShim] window.open override failed:', err);
+      console.warn("[TgShim] window.open override failed:", err);
       return originalOpen(url as any, target, features);
     }
   };
 
   installed = true;
-  // eslint-disable-next-line no-console
-  console.log('[TgShim] window.open shim installed for Telegram webview');
+  console.log("[TgShim] window.open shim installed for Telegram webview");
 }


### PR DESCRIPTION
## Summary
- Scope Telegram window.open shim to real Telegram Mini App contexts
- Leave generic HTTP(S) popups to browser window.open so Google OAuth receives a real Window object
- Keep Telegram links and known wallet deep links routed through Telegram-specific openers
- Add regression coverage for injected Telegram.WebApp outside mini app context and Google OAuth popup behavior

## Review
No blocking findings found in the auth shim fix. Remaining test gap: wallet deep-link interception is not directly asserted by the new test, though the implementation path remains intact.

## Verification
- npm test -- telegramWindowOpenShim
- npx eslint src/shared/lib/telegramWindowOpenShim.ts src/shared/lib/__tests__/telegramWindowOpenShim.test.ts
- npm test
- npm run build

Note: full npm run lint currently fails on existing unrelated repo issues/generated dist output, not on the changed files.