### PR TITLE
Fix review findings in google-auth window.open shim

### DIFF
--- a/apps/miniapp/src/lib/isTelegram.ts
+++ b/apps/miniapp/src/lib/isTelegram.ts
@@ -35,7 +35,12 @@ export function isTelegramWebApp(): boolean {
   const hasTelegramUA = /Telegram/i.test(userAgent);
   const referrer = typeof document !== 'undefined' ? document.referrer : '';
   const fromTelegramWeb = /web\.telegram\.(org|me)/i.test(referrer);
-  const isIframe = typeof window !== 'undefined' && window.top !== window;
+  let isIframe = false;
+  try {
+    isIframe = typeof window !== 'undefined' && window.top !== window;
+  } catch {
+    isIframe = true;
+  }
 
   // 2) Telegram injects tgWebApp* params in URL
   const hasTgParams = /tgWebApp/i.test(search);

--- a/apps/miniapp/src/shared/lib/__tests__/telegramWindowOpenShim.test.ts
+++ b/apps/miniapp/src/shared/lib/__tests__/telegramWindowOpenShim.test.ts
@@ -30,7 +30,8 @@ describe('installTelegramWindowOpenShim', () => {
   it("leaves generic https popups to the browser when running in a real Telegram mini app context", async () => {
     const openLink = vi.fn();
     const popup = {} as Window;
-    window.open = vi.fn(() => popup);
+    const nativeOpenSpy = vi.fn(() => popup);
+    window.open = nativeOpenSpy;
     (window as any).Telegram = {
       WebApp: {
         version: "7.0",
@@ -47,5 +48,10 @@ describe('installTelegramWindowOpenShim', () => {
 
     expect(result).toBe(popup);
     expect(openLink).not.toHaveBeenCalled();
+    expect(nativeOpenSpy).toHaveBeenCalledWith(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+      "_blank",
+      undefined,
+    );
   });
 });

--- a/apps/miniapp/src/shared/lib/telegramWindowOpenShim.ts
+++ b/apps/miniapp/src/shared/lib/telegramWindowOpenShim.ts
@@ -8,12 +8,12 @@
  * such as Google rely on receiving a real Window object from window.open().
  */
 
+import { isTelegramWebApp } from '@/lib/isTelegram';
+
 type TgWebApp = {
-  initData?: string;
   openLink?: (url: string, options?: { try_instant_view?: boolean }) => void;
   openTelegramLink?: (url: string) => void;
   platform?: string;
-  version?: string;
 };
 
 const WALLET_SCHEMES = [
@@ -42,29 +42,6 @@ function getWebApp(): TgWebApp | null {
   return (window as any).Telegram?.WebApp ?? null;
 }
 
-function hasRealTelegramMiniAppSignal(webApp: TgWebApp): boolean {
-  if (typeof window === "undefined") return false;
-
-  const initData = typeof webApp.initData === "string" ? webApp.initData.trim() : "";
-  if (initData.length > 0) return true;
-
-  const search = window.location?.search ?? "";
-  const hasTgParams = /tgWebApp/i.test(search);
-  const overrideParam = /(?:^|[?&])tma=(1|true)(?:&|$)/i.test(search);
-  const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
-  const hasTelegramUA = /Telegram/i.test(userAgent);
-  const referrer = typeof document !== "undefined" ? document.referrer : "";
-  const fromTelegramWeb = /web\.telegram\.(org|me)/i.test(referrer);
-  const isIframe = window.top !== window;
-  const host = window.location.hostname.toLowerCase();
-
-  if (/^web\.telegram\.(org|me)$/i.test(host)) return true;
-  if ((hasTgParams || overrideParam) && (hasTelegramUA || fromTelegramWeb || isIframe)) return true;
-  if (isIframe && typeof webApp.version === "string" && (hasTelegramUA || fromTelegramWeb)) return true;
-
-  return false;
-}
-
 let installed = false;
 
 export function installTelegramWindowOpenShim(): void {
@@ -72,34 +49,34 @@ export function installTelegramWindowOpenShim(): void {
   if (typeof window === "undefined") return;
 
   const webApp = getWebApp();
-  if (!webApp || !hasRealTelegramMiniAppSignal(webApp)) return;
+  if (!webApp || !isTelegramWebApp()) return;
 
   const originalOpen = window.open.bind(window);
 
-  const callTelegramLinkOpener = (open: ((url: string, options?: { try_instant_view?: boolean }) => void) | undefined, href: string) => {
-    if (!open) return originalOpen(href, "_blank");
-
+  const withOriginalOpen = (fn: () => void): null => {
     const shimmedOpen = window.open;
     try {
       window.open = originalOpen;
-      open(href, { try_instant_view: false });
+      fn();
       return null;
     } finally {
       window.open = shimmedOpen;
     }
   };
 
-  const callTelegramInternalOpener = (href: string) => {
-    if (!webApp.openTelegramLink) return originalOpen(href, "_blank");
+  const callTelegramLinkOpener = (
+    open: ((url: string, options?: { try_instant_view?: boolean }) => void) | undefined,
+    href: string,
+    target?: string,
+    features?: string,
+  ) => {
+    if (!open) return originalOpen(href, target, features);
+    return withOriginalOpen(() => open(href, { try_instant_view: false }));
+  };
 
-    const shimmedOpen = window.open;
-    try {
-      window.open = originalOpen;
-      webApp.openTelegramLink(href);
-      return null;
-    } finally {
-      window.open = shimmedOpen;
-    }
+  const callTelegramInternalOpener = (href: string, target?: string, features?: string) => {
+    if (!webApp.openTelegramLink) return originalOpen(href, target, features);
+    return withOriginalOpen(() => webApp.openTelegramLink!(href));
   };
 
   (window as any).open = (
@@ -112,11 +89,11 @@ export function installTelegramWindowOpenShim(): void {
       if (!href) return originalOpen(url as any, target, features);
 
       if (href.startsWith("tg://") || href.startsWith("https://t.me/")) {
-        return callTelegramInternalOpener(href);
+        return callTelegramInternalOpener(href, target, features);
       }
 
       if (isWalletDeepLink(href)) {
-        return callTelegramLinkOpener(webApp.openLink, href);
+        return callTelegramLinkOpener(webApp.openLink, href, target, features);
       }
 
       return originalOpen(url as any, target, features);


### PR DESCRIPTION
## Summary

- **Replace duplicate detection logic**: Deleted `hasRealTelegramMiniAppSignal` and replaced it with `isTelegramWebApp()` from `src/lib/isTelegram` — the canonical implementation. The old function diverged from the canonical one: its iframe+version check wrongly required a Telegram UA or referrer, causing the shim to skip installation in valid Telegram Web iframe contexts and leaving wallet deep links broken there. It also lacked the `sessionStorage` persistence for the `?tma=1` override.
- **Fix SecurityError in sandboxed iframes**: Wrapped `window.top !== window` in `isTelegram.ts` in a `try/catch` so a `SecurityError` from a CSP-sandboxed cross-origin iframe is caught and treated as `isIframe = true` rather than crashing `isTelegramWebApp()`.
- **Fix fallback dropping caller's `target` and `features`**: `callTelegramLinkOpener` and `callTelegramInternalOpener` were hardcoding `"_blank"` in their fallback paths, discarding the caller's intent. Both now forward `target` and `features` through.
- **Unify duplicate scaffolding**: Extracted `withOriginalOpen(fn)` to replace the copy-pasted save/restore pattern in both helper closures.
- **Strengthen test assertion**: Named the native open spy and added `toHaveBeenCalledWith` to verify the shim actually delegates to the captured original with the correct URL, target, and features — not just that the return value happened to match.

## Test plan

- [ ] `npm test -- telegramWindowOpenShim` — both tests pass
- [ ] Verify Google OAuth popup still receives a real `Window` object in a Telegram Mini App context
- [ ] Verify wallet deep links (`wc:`, `metamask:`, `trust:`, etc.) are still routed through `webApp.openLink` in a real TMA context
- [ ] Verify `tg://` and `t.me/` links still route through `webApp.openTelegramLink`